### PR TITLE
Update event docs

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -15,3 +15,8 @@
 ### Fork Pull Request Workflows
 
 By default, Pull Requests based on Forks do NOT trigger a workflow<br />Reason: Everyone can fork & open pull requests. Malicious workflow runs & excess cost could be caused. This is why First-time contributors must be approved manually.
+
+### Cancelling & Skipping
+
+**Cancelling:** By default, workflows get cancelled if a Job fails. A Job fails if at least one Step fails. A workflow can be cancelled manually.<br/>
+**Skipping:** By default, all matching events start a workflow, but there are exceptions for "_push_" and "_pull_request_". Skip can be done with a proper commit message.

--- a/docs/events.md
+++ b/docs/events.md
@@ -6,6 +6,8 @@
 
 ![events](./images/events.excalidraw.png)
 
+All possible event can be found in the [official docs](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows).
+
 ## Activity Types & Filters
 
 ![activity types and filters](./images/activity-types-filters.excalidraw.png)

--- a/docs/events.md
+++ b/docs/events.md
@@ -9,3 +9,9 @@
 ## Activity Types & Filters
 
 ![activity types and filters](./images/activity-types-filters.excalidraw.png)
+
+## Quick Notes about Events
+
+### Fork Pull Request Workflows
+
+By default, Pull Requests based on Forks do NOT trigger a workflow<br />Reason: Everyone can fork & open pull requests. Malicious workflow runs & excess cost could be caused. This is why First-time contributors must be approved manually.


### PR DESCRIPTION
This is a PR to update the documentation about Events in GitHub Actions.

It is also a test for the _pull\_request_ trigger.